### PR TITLE
feat: add support for parsing slice of strings

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -281,6 +281,13 @@ func (p *Parser) parseField(sf reflect.StructField) error {
 	case reflect.Float32, reflect.Float64:
 		f.ValidateFn = validateFloat
 		f.CovertFn = convertFloat
+	case reflect.Slice:
+		switch elemType := typ.Elem(); elemType.Kind() {
+		case reflect.String:
+			f.ValidateFn = validateString
+		default:
+			return fmt.Errorf("rql: field type for %q is not supported", sf.Name)
+		}
 	case reflect.Struct:
 		switch v := reflect.Zero(typ); v.Interface().(type) {
 		case sql.NullBool:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,9 +1,12 @@
 package gorql
 
 import (
+	"database/sql"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func FuzzParse(f *testing.F) {
@@ -21,6 +24,12 @@ type ParseURLTest struct {
 	URL            string      // Input URL
 	WantParseError bool        // Test should raise an error when parsing the RQL query
 	Model          interface{} // Input Model for query
+}
+
+type ParseFieldTest struct {
+	Name        string
+	StructField reflect.StructField
+	WantError   bool
 }
 
 var parseURLTests = []ParseURLTest{
@@ -66,6 +75,276 @@ func TestParseURL(t *testing.T) {
 	}
 }
 
+func TestParseField(t *testing.T) {
+	for _, test := range parseFieldTests {
+		test.Run(t)
+	}
+}
+
+var parseFieldTests = []ParseFieldTest{
+	{
+		Name: "Basic sortable field",
+		StructField: reflect.StructField{
+			Name: "Foo",
+			Tag:  `rql:"sort"`,
+			Type: reflect.TypeOf(""),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Basic filterable field",
+		StructField: reflect.StructField{
+			Name: "Price",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(0.0),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Field with replacewith option",
+		StructField: reflect.StructField{
+			Name: "Bar",
+			Tag:  `rql:"replacewith=bar_column"`,
+			Type: reflect.TypeOf(""),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Field with invalid layout",
+		StructField: reflect.StructField{
+			Name: "CreatedAt",
+			Tag:  `rql:"layout=invalid_layout"`,
+			Type: reflect.TypeOf(time.Time{}),
+		},
+		WantError: true,
+	},
+	{
+		Name: "Field with valid layout",
+		StructField: reflect.StructField{
+			Name: "CreatedAt",
+			Tag:  `rql:"layout=2006-01-02T15:04:05Z07:00"`,
+			Type: reflect.TypeOf(time.Time{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Unsupported field type",
+		StructField: reflect.StructField{
+			Name: "Unsupported",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf([]int{}),
+		},
+		WantError: true,
+	},
+	{
+		Name: "Field with column option",
+		StructField: reflect.StructField{
+			Name: "Baz",
+			Tag:  `rql:"column=baz_column"`,
+			Type: reflect.TypeOf(""),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Bool field",
+		StructField: reflect.StructField{
+			Name: "BoolField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(true),
+		},
+		WantError: false,
+	},
+	{
+		Name: "String field",
+		StructField: reflect.StructField{
+			Name: "StringField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(""),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Int field",
+		StructField: reflect.StructField{
+			Name: "IntField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(int(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Int8 field",
+		StructField: reflect.StructField{
+			Name: "Int8Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(int8(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Int16 field",
+		StructField: reflect.StructField{
+			Name: "Int16Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(int16(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Int32 field",
+		StructField: reflect.StructField{
+			Name: "Int32Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(int32(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Int64 field",
+		StructField: reflect.StructField{
+			Name: "Int64Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(int64(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uint field",
+		StructField: reflect.StructField{
+			Name: "UintField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uint(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uint8 field",
+		StructField: reflect.StructField{
+			Name: "Uint8Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uint8(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uint16 field",
+		StructField: reflect.StructField{
+			Name: "Uint16Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uint16(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uint32 field",
+		StructField: reflect.StructField{
+			Name: "Uint32Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uint32(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uint64 field",
+		StructField: reflect.StructField{
+			Name: "Uint64Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uint64(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Uintptr field",
+		StructField: reflect.StructField{
+			Name: "UintptrField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(uintptr(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Float32 field",
+		StructField: reflect.StructField{
+			Name: "Float32Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(float32(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Float64 field",
+		StructField: reflect.StructField{
+			Name: "Float64Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(float64(0)),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Slice of strings field",
+		StructField: reflect.StructField{
+			Name: "StringSliceField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf([]string{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Unsupported slice element type",
+		StructField: reflect.StructField{
+			Name: "UnsupportedSliceField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf([]int{}),
+		},
+		WantError: true,
+	},
+	{
+		Name: "sql.NullBool field",
+		StructField: reflect.StructField{
+			Name: "NullBoolField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(sql.NullBool{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "sql.NullString field",
+		StructField: reflect.StructField{
+			Name: "NullStringField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(sql.NullString{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "sql.NullInt64 field",
+		StructField: reflect.StructField{
+			Name: "NullInt64Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(sql.NullInt64{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "sql.NullFloat64 field",
+		StructField: reflect.StructField{
+			Name: "NullFloat64Field",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(sql.NullFloat64{}),
+		},
+		WantError: false,
+	},
+	{
+		Name: "Convertible to time.Time field",
+		StructField: reflect.StructField{
+			Name: "ConvertibleTimeField",
+			Tag:  `rql:"filter"`,
+			Type: reflect.TypeOf(time.Time{}),
+		},
+		WantError: false,
+	},
+}
+
 func (p ParseURLTest) Run(t *testing.T) {
 	parser, err := NewParser(&Config{Model: p.Model})
 	if err != nil {
@@ -75,5 +354,16 @@ func (p ParseURLTest) Run(t *testing.T) {
 	_, err = parser.ParseURL(u.Query())
 	if p.WantParseError != (err != nil) {
 		t.Fatalf("(%s) Expecting parse error :%v\nGot error : %v", p.Name, p.WantParseError, err)
+	}
+}
+
+func (p ParseFieldTest) Run(t *testing.T) {
+	parser, err := NewParser(&Config{TagName: "rql", Model: struct{}{}})
+	if err != nil {
+		t.Fatalf("New parser error: %v", err)
+	}
+	err = parser.parseField(p.StructField)
+	if p.WantError != (err != nil) {
+		t.Fatalf("(%s) Expecting error: %v, got: %v", p.Name, p.WantError, err)
 	}
 }


### PR DESCRIPTION
This pull request introduces support for parsing slices of strings in the package. The following changes have been made:

- Added a case for reflect.Slice in the type switch.
- Implemented a nested switch to handle slices of strings with validateString.

edit:
- Added test cases for parseField function and increased covereage of parser.go to 63.10% from 55.60%