### PR TITLE
refactor: replace ARRAY_CONTAINS with ARRAY_CONTAINS_ALL for cosmos driver

### DIFF
--- a/pkg/driver/cosmos/cosmos_test.go
+++ b/pkg/driver/cosmos/cosmos_test.go
@@ -150,11 +150,19 @@ var tests = []Test{
 		Model: new(struct {
 			Foo string `rql:"filter"`
 		}),
-		ExpectedSQL: `WHERE ARRAY_CONTAINS(@p1, c.foo, false)`,
+		ExpectedSQL: `WHERE ARRAY_CONTAINS_ALL(c.foo, @p1, @p2, @p3)`,
 		ExpectedArgs: []interface{}{
 			Param{
 				Name:  "@p1",
-				Value: []interface{}{"bar", "john", "doe"},
+				Value: "bar",
+			},
+			Param{
+				Name:  "@p2",
+				Value: "john",
+			},
+			Param{
+				Name:  "@p3",
+				Value: "doe",
 			},
 		},
 		WantParseError:      false,


### PR DESCRIPTION
This pull request updates the InOp operation in the Cosmos driver to use ARRAY_CONTAINS_ALL instead of ARRAY_CONTAINS. The following changes have been made:

- Updated the InOp operation to use ARRAY_CONTAINS_ALL
- Updated GetSliceTranslatorFunc to generate statement for ARRAY_CONTAINS_ALL