### PR TITLE
Feat/improve cosmos query

### DIFF
--- a/pkg/driver/cosmos/cosmos_test.go
+++ b/pkg/driver/cosmos/cosmos_test.go
@@ -145,7 +145,7 @@ var tests = []Test{
 		WantTranslatorError: false,
 	},
 	{
-		Name: `Basic translation for STARTS_WITH ignore case operator`,
+		Name: `Basic translation for STARTSWITH ignore case operator`,
 		RQL:  `match(foo,whoam*)`,
 		Model: new(struct {
 			Foo string `rql:"filter"`
@@ -155,7 +155,7 @@ var tests = []Test{
 		WantTranslatorError: false,
 	},
 	{
-		Name: `Basic translation for ENDS_WITH ignore case operator`,
+		Name: `Basic translation for ENDSWITH ignore case operator`,
 		RQL:  `match(foo,*whoam)`,
 		Model: new(struct {
 			Foo string `rql:"filter"`

--- a/pkg/driver/cosmos/cosmos_test.go
+++ b/pkg/driver/cosmos/cosmos_test.go
@@ -136,11 +136,31 @@ var tests = []Test{
 	},
 	{
 		Name: `Basic translation for CONTAINS ignore case operator`,
-		RQL:  `match(foo,whoam*)`,
+		RQL:  `match(foo,*whoam*)`,
 		Model: new(struct {
 			Foo string `rql:"filter"`
 		}),
 		ExpectedSQL:         `WHERE CONTAINS(c.foo, @p1, true)`,
+		WantParseError:      false,
+		WantTranslatorError: false,
+	},
+	{
+		Name: `Basic translation for STARTS_WITH ignore case operator`,
+		RQL:  `match(foo,whoam*)`,
+		Model: new(struct {
+			Foo string `rql:"filter"`
+		}),
+		ExpectedSQL:         `WHERE STARTSWITH(c.foo, @p1, true)`,
+		WantParseError:      false,
+		WantTranslatorError: false,
+	},
+	{
+		Name: `Basic translation for ENDS_WITH ignore case operator`,
+		RQL:  `match(foo,*whoam)`,
+		Model: new(struct {
+			Foo string `rql:"filter"`
+		}),
+		ExpectedSQL:         `WHERE ENDSWITH(c.foo, @p1, true)`,
 		WantParseError:      false,
 		WantTranslatorError: false,
 	},


### PR DESCRIPTION
- Problem statement: Cosmos db `CONTAINS` keyword doesn't support `%` for pattern matching.
- Prior to this commit, for `match` operation, the translator is replacing `*` from rql into `%`, which doesn't work as expected.
- This commit updates the translator to use:
  1. CONTAINS to achieve `like("*foo*")`
  2. ENDSWITH to achieve `like("*foo")`
  3. STARTSWITH to achieve `like("foo*")`

references:
https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/contains
https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/endswith
https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/startswith